### PR TITLE
[FEATURE] Repository details screen

### DIFF
--- a/app/src/main/java/com/nedkuj/github/feature/repositorydetails/RepositoryDetailsFragment.kt
+++ b/app/src/main/java/com/nedkuj/github/feature/repositorydetails/RepositoryDetailsFragment.kt
@@ -1,9 +1,11 @@
 package com.nedkuj.github.feature.repositorydetails
 
-import androidx.lifecycle.Lifecycle
+import androidx.navigation.fragment.navArgs
+import com.jakewharton.rxbinding3.view.clicks
 import com.nedkuj.github.R
 import com.nedkuj.github.common.BaseFragment
 import com.nedkuj.github.databinding.FragmentRepositoryDetailsBinding
+import com.nedkuj.github.model.Repository
 import com.nedkuj.github.util.rxlifecycle.RxLifecycle
 import dagger.hilt.android.AndroidEntryPoint
 import io.reactivex.Observable
@@ -17,12 +19,16 @@ class RepositoryDetailsFragment :
     @Inject
     override lateinit var presenter: RepositoryDetailsPresenter
 
+    private val args: RepositoryDetailsFragmentArgs by navArgs()
+
     override fun initUI() {
         super.initUI()
         binding.context = this
     }
 
-    override fun onLoad(): Observable<Lifecycle.Event> = RxLifecycle.onResume(this)
+    override fun onLoad(): Observable<Repository> = RxLifecycle.onResume(this).map { args.repository }
+    override fun onUserDetails(): Observable<Unit> = binding.ownerDetailsBtn.clicks()
+    override fun onRepoDetails(): Observable<Unit> = binding.repoDetailsBtn.clicks()
 
     override fun render(viewState: RepositoryDetailsFullViewState) {
         bindingData.data.set(viewState)

--- a/app/src/main/java/com/nedkuj/github/feature/repositorydetails/RepositoryDetailsPresenter.kt
+++ b/app/src/main/java/com/nedkuj/github/feature/repositorydetails/RepositoryDetailsPresenter.kt
@@ -5,16 +5,22 @@ import android.net.Uri
 import com.nedkuj.github.BuildConfig
 import com.nedkuj.github.common.BasePresenter
 import com.nedkuj.github.di.fragment.Navigator
+import com.nedkuj.github.network.repository.GetUserDataRepository
 import io.reactivex.Observable
 import javax.inject.Inject
 
 class RepositoryDetailsPresenter @Inject constructor(
-    private val navigator: Navigator
+    private val navigator: Navigator,
+    private val getUserDataRepository: GetUserDataRepository
 ) : BasePresenter<RepositoryDetailsView, RepositoryDetailsViewState, RepositoryDetailsFullViewState>() {
     override fun bindIntents() {
         val onLoad = intent(RepositoryDetailsView::onLoad)
             .switchMapToViewState(
-                { Observable.just(it) },
+                { repository ->
+                    getUserDataRepository.fetch(repository.owner.login).map { owner ->
+                        repository.copy(owner = owner)
+                    }
+                },
                 { RepositoryDetailsSuccessViewState(it) },
                 { throwable, _ -> RepositoryDetailsErrorViewState(throwable) },
                 { RepositoryDetailsLoadingViewState(true) }

--- a/app/src/main/java/com/nedkuj/github/feature/repositorydetails/RepositoryDetailsPresenter.kt
+++ b/app/src/main/java/com/nedkuj/github/feature/repositorydetails/RepositoryDetailsPresenter.kt
@@ -1,21 +1,54 @@
 package com.nedkuj.github.feature.repositorydetails
 
+import android.content.Intent
+import android.net.Uri
+import com.nedkuj.github.BuildConfig
 import com.nedkuj.github.common.BasePresenter
+import com.nedkuj.github.di.fragment.Navigator
 import io.reactivex.Observable
 import javax.inject.Inject
 
-class RepositoryDetailsPresenter @Inject constructor() :
-    BasePresenter<RepositoryDetailsView, RepositoryDetailsViewState, RepositoryDetailsFullViewState>() {
+class RepositoryDetailsPresenter @Inject constructor(
+    private val navigator: Navigator
+) : BasePresenter<RepositoryDetailsView, RepositoryDetailsViewState, RepositoryDetailsFullViewState>() {
     override fun bindIntents() {
         val onLoad = intent(RepositoryDetailsView::onLoad)
             .switchMapToViewState(
                 { Observable.just(it) },
-                { RepositoryDetailsSuccessViewState() },
+                { RepositoryDetailsSuccessViewState(it) },
                 { throwable, _ -> RepositoryDetailsErrorViewState(throwable) },
                 { RepositoryDetailsLoadingViewState(true) }
             )
 
-        subscribeForViewStateChanges(onLoad)
+        val onRepoDetails = intent(RepositoryDetailsView::onRepoDetails)
+            .switchMapToViewState(
+                { Observable.just(it) },
+                { RepositoryDetailsUrlViewState(latestViewState.repository?.full_name) },
+                { throwable, _ -> RepositoryDetailsErrorViewState(throwable) },
+                { RepositoryDetailsLoadingViewState(true) }
+            ).executeActionOn<RepositoryDetailsUrlViewState> { state ->
+                state.url?.let { param ->
+                    val intent = Intent(Intent.ACTION_VIEW)
+                    intent.data = Uri.parse(BuildConfig.WEB + param)
+                    navigator.startActivityIntent(intent)
+                }
+            }.emmitAfter<RepositoryDetailsUrlViewState> { RepositoryDetailsUrlViewState(null) }
+
+        val onUserDetails = intent(RepositoryDetailsView::onUserDetails)
+            .switchMapToViewState(
+                { Observable.just(it) },
+                { RepositoryDetailsUrlViewState(latestViewState.repository?.owner?.login) },
+                { throwable, _ -> RepositoryDetailsErrorViewState(throwable) },
+                { RepositoryDetailsLoadingViewState(true) }
+            ).executeActionOn<RepositoryDetailsUrlViewState> { state ->
+                state.url?.let { param ->
+                    val intent = Intent(Intent.ACTION_VIEW)
+                    intent.data = Uri.parse(BuildConfig.WEB + param)
+                    navigator.startActivityIntent(intent)
+                }
+            }.emmitAfter<RepositoryDetailsUrlViewState> { RepositoryDetailsUrlViewState(null) }
+
+        subscribeForViewStateChanges(onLoad, onRepoDetails, onUserDetails)
     }
 
     override fun viewStateReducer(
@@ -23,9 +56,10 @@ class RepositoryDetailsPresenter @Inject constructor() :
         changes: RepositoryDetailsViewState
     ): RepositoryDetailsFullViewState {
         return when (changes) {
-            is RepositoryDetailsSuccessViewState -> previousState.copy(loading = false)
+            is RepositoryDetailsSuccessViewState -> previousState.copy(loading = false, repository = changes.repository)
             is RepositoryDetailsLoadingViewState -> previousState.copy(loading = changes.loading)
             is RepositoryDetailsErrorViewState -> previousState.copy(loading = false, error = changes.error)
+            is RepositoryDetailsUrlViewState -> previousState.copy(url = changes.url)
         }
     }
 

--- a/app/src/main/java/com/nedkuj/github/feature/repositorydetails/RepositoryDetailsView.kt
+++ b/app/src/main/java/com/nedkuj/github/feature/repositorydetails/RepositoryDetailsView.kt
@@ -1,9 +1,11 @@
 package com.nedkuj.github.feature.repositorydetails
 
-import androidx.lifecycle.Lifecycle
 import com.nedkuj.github.common.BaseView
+import com.nedkuj.github.model.Repository
 import io.reactivex.Observable
 
 interface RepositoryDetailsView : BaseView<RepositoryDetailsFullViewState> {
-    fun onLoad(): Observable<Lifecycle.Event>
+    fun onLoad(): Observable<Repository>
+    fun onRepoDetails(): Observable<Unit>
+    fun onUserDetails(): Observable<Unit>
 }

--- a/app/src/main/java/com/nedkuj/github/feature/repositorydetails/RepositoryDetailsViewState.kt
+++ b/app/src/main/java/com/nedkuj/github/feature/repositorydetails/RepositoryDetailsViewState.kt
@@ -1,6 +1,7 @@
 package com.nedkuj.github.feature.repositorydetails
 
 import android.os.Parcelable
+import com.nedkuj.github.model.Repository
 import kotlinx.parcelize.Parcelize
 
 sealed class RepositoryDetailsViewState
@@ -8,9 +9,12 @@ sealed class RepositoryDetailsViewState
 @Parcelize
 data class RepositoryDetailsFullViewState(
     val loading: Boolean? = null,
-    val error: Throwable? = null
+    val error: Throwable? = null,
+    val repository: Repository? = null,
+    val url: String? = null
 ) : Parcelable
 
-class RepositoryDetailsSuccessViewState() : RepositoryDetailsViewState()
-class RepositoryDetailsLoadingViewState(val loading: Boolean?): RepositoryDetailsViewState()
-class RepositoryDetailsErrorViewState(val error: Throwable?): RepositoryDetailsViewState()
+class RepositoryDetailsSuccessViewState(val repository: Repository?) : RepositoryDetailsViewState()
+class RepositoryDetailsLoadingViewState(val loading: Boolean?) : RepositoryDetailsViewState()
+class RepositoryDetailsErrorViewState(val error: Throwable?) : RepositoryDetailsViewState()
+class RepositoryDetailsUrlViewState(val url: String?) : RepositoryDetailsViewState()

--- a/app/src/main/java/com/nedkuj/github/feature/search/SearchFragment.kt
+++ b/app/src/main/java/com/nedkuj/github/feature/search/SearchFragment.kt
@@ -9,6 +9,7 @@ import com.nedkuj.github.databinding.FragmentSearchBinding
 import com.nedkuj.github.extension.onResult
 import com.nedkuj.github.extension.onScrollListener
 import com.nedkuj.github.feature.search.adapter.SearchAdapter
+import com.nedkuj.github.model.Repository
 import com.nedkuj.github.util.rxlifecycle.RxLifecycle
 import dagger.hilt.android.AndroidEntryPoint
 import io.reactivex.Observable
@@ -39,7 +40,7 @@ class SearchFragment : BaseFragment<SearchFullViewState, FragmentSearchBinding>(
         .filter { it && binding.searchField.text.toString().isNotEmpty() }
         .map { binding.searchField.text.toString() }
 
-    override fun onRepoClick(): Observable<String> = searchAdapter.onItemPressed
+    override fun onRepoClick(): Observable<Repository> = searchAdapter.onItemPressed
     override fun onUserImageClick(): Observable<String> = searchAdapter.onUserImagePressed
 
     override fun onSortClick(): Observable<Unit> = binding.sortIcon.clicks()

--- a/app/src/main/java/com/nedkuj/github/feature/search/SearchPresenter.kt
+++ b/app/src/main/java/com/nedkuj/github/feature/search/SearchPresenter.kt
@@ -7,7 +7,7 @@ import com.nedkuj.github.common.BasePresenter
 import com.nedkuj.github.di.fragment.Navigator
 import com.nedkuj.github.model.SearchReposPayload
 import com.nedkuj.github.model.SortState
-import com.nedkuj.github.model.response.ResponseObject
+import com.nedkuj.github.model.response.RepoResponseObject
 import com.nedkuj.github.network.repository.GetReposDataRepository
 import io.reactivex.Observable
 import javax.inject.Inject
@@ -25,7 +25,7 @@ class SearchPresenter @Inject constructor(
                             SearchReposPayload(1, BuildConfig.PAGINATION_LIMIT, queryText, latestViewState.sortState?.value)
                         )
                     } else {
-                        Observable.just(ResponseObject(mutableListOf()))
+                        Observable.just(RepoResponseObject(mutableListOf()))
                     }
                 },
                 { SearchSuccessViewState(it.items) },

--- a/app/src/main/java/com/nedkuj/github/feature/search/SearchView.kt
+++ b/app/src/main/java/com/nedkuj/github/feature/search/SearchView.kt
@@ -2,13 +2,14 @@ package com.nedkuj.github.feature.search
 
 import androidx.lifecycle.Lifecycle
 import com.nedkuj.github.common.BaseView
+import com.nedkuj.github.model.Repository
 import io.reactivex.Observable
 
 interface SearchView : BaseView<SearchFullViewState> {
     fun onLoad(): Observable<Lifecycle.Event>
     fun onNextPage(): Observable<String>
     fun onSearch(): Observable<String>
-    fun onRepoClick(): Observable<String>
+    fun onRepoClick(): Observable<Repository>
     fun onUserImageClick(): Observable<String>
     fun onSortClick(): Observable<Unit>
     fun onSort(): Observable<Pair<String, String?>>

--- a/app/src/main/java/com/nedkuj/github/feature/search/SearchViewState.kt
+++ b/app/src/main/java/com/nedkuj/github/feature/search/SearchViewState.kt
@@ -12,7 +12,8 @@ data class SearchFullViewState(
     val loading: Boolean? = null,
     val error: Throwable? = null,
     val repositories: List<Repository>? = null,
-    val parameter: String? = null,
+    val urlParameter: String? = null,
+    val repository: Repository? = null,
     val currentPage: Int = 1,
     val sortState: SortState? = null
 ) : Parcelable
@@ -20,7 +21,8 @@ data class SearchFullViewState(
 class SearchSuccessViewState(val repositories: List<Repository>?) : SearchViewState()
 class SearchLoadingViewState(val loading: Boolean?) : SearchViewState()
 class SearchErrorViewState(val error: Throwable?) : SearchViewState()
-class SearchNavigationViewState(val parameter: String?) : SearchViewState()
+class SearchUrlViewState(val urlParameter: String?) : SearchViewState()
+class SearchNavigationViewState(val repository: Repository?): SearchViewState()
 class SearchMoreViewState(val repositories: List<Repository>?): SearchViewState()
 class SearchMoreLoadingViewState(val loading: Boolean?, val currentPage: Int): SearchViewState()
 class SearchSortViewState(val repositories: List<Repository>?, val sortState: SortState?): SearchViewState()

--- a/app/src/main/java/com/nedkuj/github/feature/search/adapter/SearchAdapter.kt
+++ b/app/src/main/java/com/nedkuj/github/feature/search/adapter/SearchAdapter.kt
@@ -8,7 +8,7 @@ import javax.inject.Inject
 
 class SearchAdapter @Inject constructor() : BaseAdapter<Repository, SearchVH>(), SearchAdapterView {
 
-    override val onItemPressed: PublishSubject<String> = PublishSubject.create()
+    override val onItemPressed: PublishSubject<Repository> = PublishSubject.create()
     override val onUserImagePressed: PublishSubject<String> = PublishSubject.create()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SearchVH = SearchVH(parent, this)

--- a/app/src/main/java/com/nedkuj/github/feature/search/adapter/SearchAdapterView.kt
+++ b/app/src/main/java/com/nedkuj/github/feature/search/adapter/SearchAdapterView.kt
@@ -1,8 +1,9 @@
 package com.nedkuj.github.feature.search.adapter
 
+import com.nedkuj.github.model.Repository
 import io.reactivex.subjects.PublishSubject
 
 interface SearchAdapterView {
-    val onItemPressed: PublishSubject<String>
+    val onItemPressed: PublishSubject<Repository>
     val onUserImagePressed: PublishSubject<String>
 }

--- a/app/src/main/java/com/nedkuj/github/feature/search/adapter/SearchVH.kt
+++ b/app/src/main/java/com/nedkuj/github/feature/search/adapter/SearchVH.kt
@@ -19,7 +19,7 @@ class SearchVH(parent: ViewGroup, adapterView: SearchAdapterView) : BaseViewHold
 ) {
     init {
         itemView.clicks()
-                .map { data.name }
+                .map { data }
                 .subscribe(adapterView.onItemPressed)
 
         binding.ownerImage.clicks()

--- a/app/src/main/java/com/nedkuj/github/model/Owner.kt
+++ b/app/src/main/java/com/nedkuj/github/model/Owner.kt
@@ -7,5 +7,11 @@ import kotlinx.parcelize.Parcelize
 data class Owner(
         val login: String,
         val avatar_url: String,
-        val url: String
+        val url: String,
+        val type: String,
+        val name: String?,
+        val blog: String?,
+        val location: String?,
+        val email: String?,
+        val bio: String?
 ) : Parcelable

--- a/app/src/main/java/com/nedkuj/github/model/Owner.kt
+++ b/app/src/main/java/com/nedkuj/github/model/Owner.kt
@@ -1,7 +1,7 @@
 package com.nedkuj.github.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class Owner(

--- a/app/src/main/java/com/nedkuj/github/model/Repository.kt
+++ b/app/src/main/java/com/nedkuj/github/model/Repository.kt
@@ -2,18 +2,24 @@ package com.nedkuj.github.model
 
 import android.os.Parcelable
 import com.nedkuj.github.common.Entity
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
+import java.util.*
 
 @Parcelize
 data class Repository(
-        val id: Long,
-        val name: String,
-        val full_name: String,
-        val owner: Owner,
-        val url: String,
-        val forks: Int,
-        val watchers: Int,
-        val open_issues: Int
+    val id: Long,
+    val name: String,
+    val full_name: String,
+    val private: Boolean,
+    val owner: Owner,
+    val description: String,
+    val url: String,
+    val language: String,
+    val created_at: Date,
+    val updated_at: Date,
+    val forks: Int,
+    val watchers: Int,
+    val open_issues: Int
 ) : Parcelable, Entity<Long> {
     override fun id(): Long = id
 }

--- a/app/src/main/java/com/nedkuj/github/model/response/RepoResponseObject.kt
+++ b/app/src/main/java/com/nedkuj/github/model/response/RepoResponseObject.kt
@@ -5,6 +5,6 @@ import com.nedkuj.github.model.Repository
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize
-data class ResponseObject(
+data class RepoResponseObject(
         val items: List<Repository>
 ) : Parcelable

--- a/app/src/main/java/com/nedkuj/github/network/api/GitHubAPI.kt
+++ b/app/src/main/java/com/nedkuj/github/network/api/GitHubAPI.kt
@@ -1,18 +1,22 @@
 package com.nedkuj.github.network.api
 
-import com.nedkuj.github.model.response.ResponseObject
+import com.nedkuj.github.model.Owner
+import com.nedkuj.github.model.response.RepoResponseObject
 import io.reactivex.Single
 import retrofit2.http.GET
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface GitHubAPI {
 
     @GET("/search/repositories")
     fun getRepositories(
-            @Query("page") page: Int,
-            @Query("per_page") perPage: Int,
-            @Query("q") query: String,
-            @Query("sort") sort : String?
-    ): Single<ResponseObject>
+        @Query("page") page: Int,
+        @Query("per_page") perPage: Int,
+        @Query("q") query: String,
+        @Query("sort") sort: String?
+    ): Single<RepoResponseObject>
 
+    @GET("/users/{username}")
+    fun getUser(@Path("username") username: String): Single<Owner>
 }

--- a/app/src/main/java/com/nedkuj/github/network/repository/GetReposDataRepository.kt
+++ b/app/src/main/java/com/nedkuj/github/network/repository/GetReposDataRepository.kt
@@ -1,14 +1,14 @@
 package com.nedkuj.github.network.repository
 
 import com.nedkuj.github.model.SearchReposPayload
-import com.nedkuj.github.model.response.ResponseObject
+import com.nedkuj.github.model.response.RepoResponseObject
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
 
-class GetReposDataRepository @Inject constructor() : DataRepository<SearchReposPayload, ResponseObject>() {
-    override fun fetchData(payload: SearchReposPayload): Observable<ResponseObject> {
+class GetReposDataRepository @Inject constructor() : DataRepository<SearchReposPayload, RepoResponseObject>() {
+    override fun fetchData(payload: SearchReposPayload): Observable<RepoResponseObject> {
         return retrofitClient
                 .getGitHubAPI()
                 .getRepositories(payload.page, payload.perPage, payload.query, payload.sort)

--- a/app/src/main/java/com/nedkuj/github/network/repository/GetUserDataRepository.kt
+++ b/app/src/main/java/com/nedkuj/github/network/repository/GetUserDataRepository.kt
@@ -1,0 +1,18 @@
+package com.nedkuj.github.network.repository
+
+import com.nedkuj.github.model.Owner
+import io.reactivex.Observable
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.schedulers.Schedulers
+import javax.inject.Inject
+
+class GetUserDataRepository @Inject constructor() : DataRepository<String, Owner>() {
+    override fun fetchData(payload: String): Observable<Owner> {
+        return retrofitClient
+            .getGitHubAPI()
+            .getUser(payload)
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .toObservable()
+    }
+}

--- a/app/src/main/res/layout/fragment_repository_details.xml
+++ b/app/src/main/res/layout/fragment_repository_details.xml
@@ -5,15 +5,19 @@
 
     <data>
 
+        <import type="android.view.View"/>
+
         <variable
             name="context"
             type="com.nedkuj.github.feature.repositorydetails.RepositoryDetailsFragment"/>
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.constraintlayout.motion.widget.MotionLayout
+        android:id="@+id/repo_details_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:padding="@dimen/spacing_standard">
+        android:padding="@dimen/spacing_standard"
+        app:layoutDescription="@xml/fragment_repodetails_scene">
 
         <ImageView
             android:id="@+id/author_image"
@@ -29,7 +33,8 @@
             style="@style/GitHubTitleTextStyle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:text="@{context.bindingData.data.repository.owner.login}"
+            android:gravity="center_vertical"
+            android:text="@{context.bindingData.data.repository.owner.name}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/author_image"/>
@@ -133,24 +138,77 @@
             app:layout_constraintStart_toEndOf="@id/forks_count"/>
 
         <Button
-            android:id="@+id/owner_details_btn"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/spacing_small"
-            android:text="@string/owner_details"
-            app:layout_constraintEnd_toStartOf="@id/repo_details_btn"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/issues_count"/>
-
-        <Button
             android:id="@+id/repo_details_btn"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_margin="@dimen/spacing_small"
             android:text="@string/repo_details"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/owner_details_btn"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/issues_count"/>
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        <TextView
+            android:id="@+id/author_about_tw"
+            style="@style/GitHubTitleTextStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/spacing_large"
+            android:text="@string/about_the_author"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/repo_details_btn"/>
+
+        <TextView
+            android:id="@+id/author_type"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:drawablePadding="@dimen/spacing_standard"
+            android:text="@{context.bindingData.data.repository.owner.type}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/author_about_tw"/>
+
+        <TextView
+            android:id="@+id/author_blog"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:drawablePadding="@dimen/spacing_standard"
+            android:text="@{context.bindingData.data.repository.owner.blog}"
+            android:visibility="@{context.bindingData.data.repository.owner.blog != null ? View.VISIBLE : View.GONE}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/author_type"/>
+
+        <TextView
+            android:id="@+id/author_location"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:drawablePadding="@dimen/spacing_standard"
+            android:text="@{context.bindingData.data.repository.owner.location}"
+            android:visibility="@{context.bindingData.data.repository.owner.location != null ? View.VISIBLE : View.GONE}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/author_blog"/>
+
+        <TextView
+            android:id="@+id/author_email"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:drawablePadding="@dimen/spacing_standard"
+            android:text="@{context.bindingData.data.repository.owner.email}"
+            android:visibility="@{context.bindingData.data.repository.owner.email != null ? View.VISIBLE : View.GONE}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/author_location"/>
+
+        <Button
+            android:id="@+id/owner_details_btn"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/spacing_small"
+            android:text="@string/owner_details"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/author_email"/>
+
+    </androidx.constraintlayout.motion.widget.MotionLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_repository_details.xml
+++ b/app/src/main/res/layout/fragment_repository_details.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout
-    xmlns:android="http://schemas.android.com/apk/res/android">
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
 
@@ -11,7 +12,145 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:padding="@dimen/spacing_standard">
+
+        <ImageView
+            android:id="@+id/author_image"
+            android:layout_width="0dp"
+            android:layout_height="@dimen/author_image_h"
+            android:srcNetwork='@{context.bindingData.data.repository.owner.avatar_url ?? ""}'
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"/>
+
+        <TextView
+            android:id="@+id/author_name"
+            style="@style/GitHubTitleTextStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@{context.bindingData.data.repository.owner.login}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/author_image"/>
+
+        <TextView
+            android:id="@+id/repo_full_name"
+            style="@style/GithubSubtitleTextStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@{context.bindingData.data.repository.full_name}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/author_name"/>
+
+        <TextView
+            android:id="@+id/repo_description"
+            style="@style/GithubSubtitleTextStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@{context.bindingData.data.repository.description}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/repo_full_name"/>
+
+        <TextView
+            android:id="@+id/repo_visibility"
+            style="@style/GithubSubtitleTextStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/spacing_standard"
+            android:text="@{context.bindingData.data.repository.private ? @string/public_repo : @string/private_repo}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/repo_description"/>
+
+        <TextView
+            android:id="@+id/repo_language"
+            style="@style/GithubSubtitleTextStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@{@string/language_string(context.bindingData.data.repository.language)}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/repo_visibility"/>
+
+        <TextView
+            android:id="@+id/repo_creation_date"
+            style="@style/GithubSubtitleTextStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@{@string/created_at_string(context.bindingData.data.repository.created_at)}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/repo_language"/>
+
+        <TextView
+            android:id="@+id/repo_update_date"
+            style="@style/GithubSubtitleTextStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@{@string/updated_at_string(context.bindingData.data.repository.updated_at)}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/repo_creation_date"/>
+
+        <TextView
+            android:id="@+id/watchers_count"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/spacing_standard"
+            android:drawablePadding="@dimen/spacing_standard"
+            android:gravity="center"
+            android:text="@{context.bindingData.data.repository.watchers}"
+            app:drawableStartCompat="@drawable/ic_watch"
+            app:layout_constraintEnd_toStartOf="@id/forks_count"
+            app:layout_constraintStart_toStartOf="@id/repo_update_date"
+            app:layout_constraintTop_toBottomOf="@id/repo_update_date"/>
+
+        <TextView
+            android:id="@+id/forks_count"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:drawablePadding="@dimen/spacing_standard"
+            android:gravity="center"
+            android:text="@{context.bindingData.data.repository.forks}"
+            app:drawableStartCompat="@drawable/ic_fork"
+            app:layout_constraintBottom_toBottomOf="@id/watchers_count"
+            app:layout_constraintEnd_toStartOf="@id/issues_count"
+            app:layout_constraintStart_toEndOf="@id/watchers_count"/>
+
+        <TextView
+            android:id="@+id/issues_count"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:drawablePadding="@dimen/spacing_standard"
+            android:gravity="center"
+            android:text="@{context.bindingData.data.repository.open_issues}"
+            app:drawableStartCompat="@drawable/ic_issue"
+            app:layout_constraintBottom_toBottomOf="@id/watchers_count"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/forks_count"/>
+
+        <Button
+            android:id="@+id/owner_details_btn"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/spacing_small"
+            android:text="@string/owner_details"
+            app:layout_constraintEnd_toStartOf="@id/repo_details_btn"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/issues_count"/>
+
+        <Button
+            android:id="@+id/repo_details_btn"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/spacing_small"
+            android:text="@string/repo_details"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/owner_details_btn"
+            app:layout_constraintTop_toBottomOf="@id/issues_count"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -28,7 +28,8 @@
         tools:layout="@layout/fragment_repository_details">
 
         <argument
-            android:name="name"
+            android:name="repository"
+            app:argType="com.nedkuj.github.model.Repository"
             app:nullable="false"/>
     </fragment>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -16,4 +16,7 @@
 
     <!--  Search list item values  -->
     <dimen name="repo_owner_image_wh">100dp</dimen>
+
+    <!--  Repository details screen-specific  -->
+    <dimen name="author_image_h">350dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,4 +48,5 @@
     <string name="language_string">Language: %s</string>
     <string name="updated_at_string">Updated at %s</string>
     <string name="created_at_string">Created at %s</string>
+    <string name="about_the_author">About the author</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,4 +39,13 @@
     <string name="forks">Forks</string>
     <string name="updated">Updated</string>
     <string name="default_best_match">Default - best match</string>
+
+    <!--  Repository details screen  -->
+    <string name="owner_details">Owner details</string>
+    <string name="repo_details">Repo details</string>
+    <string name="public_repo">Public repository</string>
+    <string name="private_repo">Private repository</string>
+    <string name="language_string">Language: %s</string>
+    <string name="updated_at_string">Updated at %s</string>
+    <string name="created_at_string">Created at %s</string>
 </resources>

--- a/app/src/main/res/xml/fragment_repodetails_scene.xml
+++ b/app/src/main/res/xml/fragment_repodetails_scene.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MotionScene xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:motion="http://schemas.android.com/apk/res-auto">
+
+    <Transition
+        motion:constraintSetEnd="@id/end"
+        motion:constraintSetStart="@id/start"
+        motion:duration="2000">
+        <OnSwipe
+            motion:dragDirection="dragUp"
+            motion:touchAnchorId="@+id/author_about_tw"/>
+    </Transition>
+
+    <ConstraintSet android:id="@+id/start">
+        <Constraint
+            android:id="@id/author_image"
+            android:layout_width="0dp"
+            android:layout_height="@dimen/author_image_h"
+            motion:layout_constraintEnd_toEndOf="parent"
+            motion:layout_constraintStart_toStartOf="parent"
+            motion:layout_constraintTop_toTopOf="parent"/>
+
+        <Constraint
+            android:id="@id/author_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            motion:layout_constraintEnd_toEndOf="parent"
+            motion:layout_constraintStart_toStartOf="parent"
+            motion:layout_constraintTop_toBottomOf="@id/author_image"/>
+    </ConstraintSet>
+
+    <ConstraintSet android:id="@+id/end">
+        <Constraint
+            android:id="@id/author_image"
+            android:layout_width="75dp"
+            android:layout_height="75dp"
+            motion:layout_constraintStart_toStartOf="parent"
+            motion:layout_constraintTop_toTopOf="parent"/>
+
+        <Constraint
+            android:id="@id/author_name"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginStart="@dimen/spacing_standard"
+            motion:layout_constraintBottom_toBottomOf="@id/author_image"
+            motion:layout_constraintEnd_toEndOf="parent"
+            motion:layout_constraintStart_toEndOf="@id/author_image"
+            motion:layout_constraintTop_toTopOf="@id/author_image"/>
+
+        <Constraint
+            android:id="@id/repo_full_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            motion:layout_constraintStart_toStartOf="parent"
+            motion:layout_constraintEnd_toEndOf="parent"
+            motion:layout_constraintTop_toBottomOf="@id/author_image"/>
+    </ConstraintSet>
+</MotionScene>


### PR DESCRIPTION
This PR implements the repository details screen, as per following specifications:

>The repository detail screen should contain:
>- User’s thumbnail picture (bigger than in the repository list screen)
>- Name of the author
>- An extended set of information about the repository. This can be anything else you want
from the Github API like: Programming language, Date of creation, Date of last modification
>- The ability to open (navigate) the repository details in an external browser (e.g. Chrome,
Firefox)
>- The ability to open (navigate) the user details in an external browser (e.g. Chrome,
Firefox)
> Information about the owner of the repository